### PR TITLE
Correctly counts kills for Abathur Swarm Hosts

### DIFF
--- a/SC2Dictionaries/UnitAddKillsTo.csv
+++ b/SC2Dictionaries/UnitAddKillsTo.csv
@@ -9,6 +9,7 @@ FenixClolarionInterceptor,Clolarion
 Interceptor,Carrier
 InterceptorAiur,Carrier
 InterceptorStetmann,Mecha Battlecarrier Lord
+Locust,Swarm Host
 LocustMP,Swarm Host
 NovaBoombot,Nova
 NovaBoombotBurrowed,Nova


### PR DESCRIPTION
I don't believe this will affect Dehaka's locusts (DehakaLocust), or the locusts spawned from Abathur killing enemy units (AbathurLocust).

Before:

![beforegg](https://user-images.githubusercontent.com/635071/93001369-93649580-f4fc-11ea-8bd6-3ded5ed6b0be.png)


After:

![aftergg](https://user-images.githubusercontent.com/635071/93001372-98294980-f4fc-11ea-989a-c1f3a56a1f9a.png)
