### PR TITLE
Modified full analysis to use a process pool

### DIFF
--- a/SCO.py
+++ b/SCO.py
@@ -16,38 +16,39 @@ Overall it's messy with a lot of coupling, not enough separation between UI and
 core functinality, and similar issues. It's a great learning experience nevertheless.
 
 """
-import os
-import sys
 import json
+import os
 import shutil
+import sys
 import threading
 import traceback
 import urllib.request
-from functools import partial
 from datetime import datetime
+from functools import partial
+from multiprocessing import freeze_support
 
 import keyboard
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-import SCOFunctions.MUserInterface as MUI
-import SCOFunctions.MainFunctions as MF
 import SCOFunctions.HelperFunctions as HF
+import SCOFunctions.MainFunctions as MF
 import SCOFunctions.MassReplayAnalysis as MR
+import SCOFunctions.MUserInterface as MUI
 import SCOFunctions.Tabs as Tabs
-from SCOFunctions.MChatWidget import ChatWidget
-from SCOFunctions.MLogging import logclass, catch_exceptions
-from SCOFunctions.MFilePath import truePath, innerPath
-from SCOFunctions.MTwitchBot import TwitchBot
 from SCOFunctions.FastExpand import FastExpandSelector
-from SCOFunctions.MSystemInfo import SystemInfo
-from SCOFunctions.MTheming import set_dark_theme, MColors
+from SCOFunctions.MChatWidget import ChatWidget
 from SCOFunctions.MDebugWindow import DebugWindow
+from SCOFunctions.MFilePath import innerPath, truePath
+from SCOFunctions.MLogging import catch_exceptions, logclass
+from SCOFunctions.MSystemInfo import SystemInfo
+from SCOFunctions.MTheming import MColors, set_dark_theme
+from SCOFunctions.MTwitchBot import TwitchBot
 from SCOFunctions.Settings import Setting_manager as SM
 
 logger = logclass('SCO', 'INFO')
 logclass.FILE = truePath("Logs.txt")
 
-APPVERSION = 239
+APPVERSION = 240
 
 
 class Signal_Manager(QtCore.QObject):
@@ -1102,6 +1103,7 @@ class UI_TabWidget(object):
 
 
 if __name__ == "__main__":
+    freeze_support()
     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     app = QtWidgets.QApplication(sys.argv)
     TabWidget = MUI.CustomQTabWidget()

--- a/SCOFunctions/MainFunctions.py
+++ b/SCOFunctions/MainFunctions.py
@@ -16,7 +16,7 @@ import asyncio
 import websockets
 
 from SCOFunctions.MLogging import logclass
-from SCOFunctions.ReplayAnalysis import analyse_replay
+from SCOFunctions.ReplayAnalysis import parse_and_analyse_replay
 from SCOFunctions.IdentifyMap import identify_map
 from SCOFunctions.HelperFunctions import get_hash
 from SCOFunctions.Settings import Setting_manager as SM
@@ -289,7 +289,7 @@ def check_replays():
                         logger.info(f'New replay: {file_path}')
                         replay_dict = dict()
                         try:
-                            replay_dict = analyse_replay(file_path, PLAYER_HANDLES)
+                            replay_dict = parse_and_analyse_replay(file_path, PLAYER_HANDLES)
 
                             # First check if any commander found
                             if not replay_dict.get('mainCommander') and not replay_dict.get('allyCommander'):
@@ -383,7 +383,7 @@ def show_overlay(file, add_replay=True):
 
     # Didn't find the replay, analyse
     try:
-        replay_dict = analyse_replay(file, PLAYER_HANDLES)
+        replay_dict = parse_and_analyse_replay(file, PLAYER_HANDLES)
         if len(replay_dict) > 1:
             sendEvent(replay_dict)
             if CAnalysis is not None and add_replay:

--- a/SCOFunctions/MassReplayAnalysis.py
+++ b/SCOFunctions/MassReplayAnalysis.py
@@ -12,13 +12,14 @@ import traceback
 import statistics
 import threading
 from pprint import pprint
+from concurrent.futures import ProcessPoolExecutor
 
 import s2protocol
 
 from SCOFunctions.MFilePath import truePath
 from SCOFunctions.MLogging import logclass, catch_exceptions
 from SCOFunctions.S2Parser import s2_parse_replay
-from SCOFunctions.ReplayAnalysis import analyse_replay
+from SCOFunctions.ReplayAnalysis import analyse_parsed_replay, parse_replay_file
 from SCOFunctions.HelperFunctions import get_hash
 from SCOFunctions.MainFunctions import find_names_and_handles, find_replays, names_fallback
 from SCOFunctions.SC2Dictionaries import bonus_objectives, mc_units, prestige_names, map_names, units_to_stats
@@ -937,6 +938,14 @@ class mass_replay_analysis:
             if k in pdict:
                 del pdict[k]
 
+    @staticmethod
+    def _guarded_parse_replay_file(*args, **kwargs):
+        """Parse and return a replay, or return an exception if one occurred."""
+        try:
+            return parse_replay_file(*args, **kwargs)
+        except Exception as e:
+            return e
+
     def run_full_analysis(self, progress_callback):
         """ Run full analysis on all replays """
         self.closing = False
@@ -957,10 +966,20 @@ class mass_replay_analysis:
 
         # Start
         logger.info('Starting full analysis!')
+        pool = ProcessPoolExecutor()
+        results = []
         start = time.time()
         idx = 0
         eta = '?'
         for i, r in enumerate(self.ReplayDataAll):
+            if not os.path.isfile(r.file):
+                    continue
+            
+            # Analyze those that are not fully parsed yet
+            if not r.full_analysis:
+                filepath = r.file
+                results.append((i, filepath, pool.submit(mass_replay_analysis._guarded_parse_replay_file, filepath)))
+        for (i, filepath, future) in results:
             # Save cache every now and then
             if idx >= 30:
                 idx = 0
@@ -968,47 +987,50 @@ class mass_replay_analysis:
 
             # Interrupt the analysis if the app is closing
             if self.closing:
+                for (_, _, f) in results:
+                    f.cancel()
+                pool.shutdown(True)
                 self.save_cache()
                 return False
 
-            # Analyze those that are not fully parsed yet
-            if not r.full_analysis:
-                try:
-                    if not os.path.isfile(r.file):
-                        continue
+            replay = future.result()
+            if isinstance(replay, Exception):
+                e = replay
+                logger.error(f'Parsing error ({filepath})\n{traceback.format_exception(type(e), e, e.__traceback__)}')
+                continue
+            try:
+                full_data = analyse_parsed_replay(filepath, replay, self.main_handles)
+                full_data['full_analysis'] = True
+                if len(full_data) < 2:
+                    continue
 
-                    full_data = analyse_replay(r.file, self.main_handles)
+                # Update data
+                idx += 1
+                fully_parsed += 1
 
-                    full_data['full_analysis'] = True
-                    if len(full_data) < 2:
-                        continue
+                # Calculate eta
+                if (fully_parsed - fully_parsed_at_start) > 10 and (fully_parsed - fully_parsed_at_start) % 3 == 0:
+                    eta = (len(self.ReplayDataAll) - fully_parsed) / ((fully_parsed - fully_parsed_at_start) / (time.time() - start))
+                    eta = time.strftime("%H:%M:%S", time.gmtime(eta))
 
-                    # Update data
-                    idx += 1
-                    fully_parsed += 1
+                # Update widget
+                with lock:
+                    try:
+                        formated = self.format_data(full_data)
+                        if self.replay_entry_valid(formated):
+                            self.ReplayDataAll[i] = formated
+                    except Exception:
+                        logger.error(traceback.format_exc())
+                    progress_callback.emit(
+                        f'Estimated remaining time: {eta}\nRunning... {fully_parsed}/{len(self.ReplayDataAll)} ({100*fully_parsed/len(self.ReplayDataAll):.0f}%)'
+                    )
 
-                    # Calculate eta
-                    if (fully_parsed - fully_parsed_at_start) > 10 and (fully_parsed - fully_parsed_at_start) % 3 == 0:
-                        eta = (len(self.ReplayDataAll) - fully_parsed) / ((fully_parsed - fully_parsed_at_start) / (time.time() - start))
-                        eta = time.strftime("%H:%M:%S", time.gmtime(eta))
-
-                    # Update widget
-                    with lock:
-                        try:
-                            formated = self.format_data(full_data)
-                            if self.replay_entry_valid(formated):
-                                self.ReplayDataAll[i] = formated
-                        except Exception:
-                            logger.error(traceback.format_exc())
-                        progress_callback.emit(
-                            f'Estimated remaining time: {eta}\nRunning... {fully_parsed}/{len(self.ReplayDataAll)} ({100*fully_parsed/len(self.ReplayDataAll):.0f}%)'
-                        )
-
-                except Exception:
-                    logger.error(traceback.format_exc())
+            except Exception:
+                logger.error(traceback.format_exc())
 
         if idx > 0:
             self.save_cache()
+        pool.shutdown(True)
         progress_callback.emit(f'Full analysis completed! {len(self.ReplayDataAll)}/{len(self.ReplayDataAll)} | 100%')
         logger.info(f'Full analysis completed in {time.time()-start:.0f} seconds!')
         self.full_analysis_finished = True

--- a/SCOFunctions/ReplayAnalysis.py
+++ b/SCOFunctions/ReplayAnalysis.py
@@ -243,7 +243,7 @@ def parse_replay_file(filepath):
         try:
             replay = s2_parse_replay(filepath, return_events=True)
             break
-        except Exception as e:  # You can get an error here if SC2 didn't finish writing into the file. Very rare.
+        except Exception:  # You can get an error here if SC2 didn't finish writing into the file. Very rare.
             if attempt == 2:
                 raise Exception(f'Parsing error! ({filepath})')
             time.sleep(0.3)

--- a/SCOFunctions/ReplayAnalysis.py
+++ b/SCOFunctions/ReplayAnalysis.py
@@ -238,6 +238,7 @@ def unitid(event, killer=False, creator=False):
 
 
 def parse_replay_file(filepath):
+    """ Parses a replay with S2parser"""
     replay = None
     for attempt in range(3):
         try:


### PR DESCRIPTION
Should greatly speed up replay processing, depending on core count.
Tested and confirmed working by analysing ~1000 assorted replays and comparing the dump json file after both runs.

I've tried to modify the least amount of code as possible. Further analysing replays doesn't seem easy to do in a process pool.